### PR TITLE
Fix OS version minor version and error macro

### DIFF
--- a/dlls/common/common.h
+++ b/dlls/common/common.h
@@ -2,4 +2,4 @@
 #define RtlSetLastWin32ErrorAndNtStatusFromNtStatus(Status) \
     SetLastError(RtlNtStatusToDosError(Status))
 #define RtlGetLastWin32ErrorAndNtStatusFromNtStatus(Status) \
-    GetLastError(RtlNtStatusToDosError(Status))
+    (SetLastError(RtlNtStatusToDosError(Status)), GetLastError())

--- a/dlls/kernelx/kernelx.cpp
+++ b/dlls/kernelx/kernelx.cpp
@@ -229,7 +229,7 @@ void GetSystemOSVersion_X(LPSYSTEMOSVERSIONINFO VersionInformation) {
     int edx = cpuInfo[3];
 
     VersionInformation->MajorVersion = LOBYTE(ebx);             // Lowest 8 bits of EBX
-    VersionInformation->MinorVersion = HIBYTE(HIDWORD(eax));    // Highest 8 bits of EAX
+    VersionInformation->MinorVersion = HIBYTE(HIWORD(eax));     // Highest 8 bits of EAX
 
     VersionInformation->Revision = LOWORD(edx);                 // Lowest 16 bits of EDX
     VersionInformation->BuildNumber = LOWORD(eax);              // Lowest 16 bits of EAX     


### PR DESCRIPTION
## Summary
- correct CPU info minor version parsing using HIWORD
- fix macro `RtlGetLastWin32ErrorAndNtStatusFromNtStatus`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68411d808df48328a3ce32c1992c523f