### PR TITLE
Fix GSSetConstantBuffers wrapper

### DIFF
--- a/dlls/d3d11_x/device_context_x.cpp
+++ b/dlls/d3d11_x/device_context_x.cpp
@@ -127,60 +127,20 @@ void wd::device_context_x::IASetVertexBuffers(UINT StartSlot, UINT NumBuffers, I
 
 void wd::device_context_x::GSSetConstantBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers)
 {
-	if (!wrapped_interface)
-	{
-		printf("GSSetConstantBuffers: wrapped_interface is null.\n");
-		return;
-	}
+        if (ppConstantBuffers != nullptr && *ppConstantBuffers != nullptr)
+        {
+                ID3D11Buffer* modifiedBuffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
+                for (UINT i = 0; i < NumBuffers; ++i)
+                {
+                        modifiedBuffers[i] = reinterpret_cast<wd::buffer*>(ppConstantBuffers[i])->wrapped_interface;
+                }
 
-	if (!ppConstantBuffers)
-	{
-		printf("GSSetConstantBuffers: ppConstantBuffers is null.\n");
-		return;
-	}
-
-	ID3D11Device* contextDevice = nullptr;
-	wrapped_interface->GetDevice(&contextDevice);
-
-	if (!contextDevice)
-	{
-		printf("GSSetConstantBuffers: failed to retrieve context device.\n");
-		return;
-	}
-
-	for (UINT i = 0; i < NumBuffers; ++i)
-	{
-		ID3D11Buffer* buffer = ppConstantBuffers[ i ];
-		if (!buffer)
-		{
-			printf("GSSetConstantBuffers: buffer at index %u is null.\n", i);
-			continue; // Optional: could return instead
-		}
-
-		ID3D11Device* bufferDevice = nullptr;
-		buffer->GetDevice(&bufferDevice);
-
-		if (!bufferDevice)
-		{
-			printf("GSSetConstantBuffers: buffer at index %u has no device.\n", i);
-			contextDevice->Release( );
-			return;
-		}
-
-		if (bufferDevice != contextDevice)
-		{
-			printf("GSSetConstantBuffers: buffer at index %u was created from a different device.\n", i);
-			bufferDevice->Release( );
-			contextDevice->Release( );
-			return;
-		}
-
-		bufferDevice->Release( );
-	}
-
-	contextDevice->Release( );
-
-	wrapped_interface->GSSetConstantBuffers(StartSlot, NumBuffers, ppConstantBuffers);
+                wrapped_interface->GSSetConstantBuffers(StartSlot, NumBuffers, modifiedBuffers);
+        }
+        else
+        {
+                wrapped_interface->GSSetConstantBuffers(StartSlot, NumBuffers, ppConstantBuffers);
+        }
 }
 
 


### PR DESCRIPTION
## Summary
- remove placeholder GSSetConstantBuffers logic
- forward GSSetConstantBuffers to underlying interface like other shader stages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68412415062483289260137a76c49e12